### PR TITLE
Remove unused features and replace FMA with ILX terms

### DIFF
--- a/anatomical_map.json
+++ b/anatomical_map.json
@@ -687,7 +687,7 @@
         "term": "UBERON:0002017",
         "name": "portal vein"
     },
-	"reproductive_1": {
+    "reproductive_1": {
         "term": "UBERON:0000995",
         "name": "uterus"
     },
@@ -1112,11 +1112,11 @@
         "name": "sympathetic trunk"
     },
     "spinal_48": {
-        "term": "FMA:5875",
+        "term": "ILX:0794742",
         "name": "White communicating ramus"
     },
     "spinal_49": {
-        "term": "FMA:5876",
+        "term": "ILX:0794739",
         "name": "Gray communicating ramus"
     },
     "spinal_50": {
@@ -1390,10 +1390,6 @@
     "bolser_22": {
         "term": "UBERON:0009009",
         "name": "carotid sinus nerve"
-    },
-    "bolser_8": {
-        "term": "UBERON:0001650",
-        "name": "hypoglossal nerve"
     },
     "bolser_13": {
         "term": "ILX:0738373",

--- a/connectivity_terms.json
+++ b/connectivity_terms.json
@@ -7,13 +7,6 @@
         ]
     },
     {
-        "id": "ILX:0790146",
-        "name": "Anterior root of fifth thoracic nerve",
-        "aliases": [
-            "FMA:12900"
-        ]
-    },
-    {
         "id": "ILX:0785421",
         "name": "Anterior root of first lumbar nerve",
         "aliases": [
@@ -28,52 +21,10 @@
         ]
     },
     {
-        "id": "ILX:0787722",
-        "name": "Anterior root of first thoracic nerve",
-        "aliases": [
-            "FMA:7643"
-        ]
-    },
-    {
-        "id": "ILX:0792838",
-        "name": "Anterior root of fourth thoracic nerve",
-        "aliases": [
-            "FMA:12899"
-        ]
-    },
-    {
         "id": "ILX:0788675",
         "name": "Anterior root of second lumbar nerve",
         "aliases": [
             "EMAPA:25271"
-        ]
-    },
-    {
-        "id": "ILX:0789894",
-        "name": "Anterior root of second thoracic nerve",
-        "aliases": [
-            "FMA:12897"
-        ]
-    },
-    {
-        "id": "ILX:0791062",
-        "name": "Anterior root of sixth thoracic nerve",
-        "aliases": [
-            "FMA:12901"
-        ]
-    },
-    {
-        "id": "ILX:0784804",
-        "name": "Anterior root of third thoracic nerve",
-        "aliases": [
-            "FMA:12898"
-        ]
-    },
-    {
-        "id": "UBERON:0000947",
-        "name": "aorta",
-        "aliases": [
-            "FMA:3734"
         ]
     },
     {
@@ -105,13 +56,6 @@
         ]
     },
     {
-        "id": "UBERON:0002870",
-        "name": "dorsal motor nucleus of vagus nerve",
-        "aliases": [
-            "FMA:54592"
-        ]
-    },
-    {
         "id": "UBERON:0000388",
         "name": "epiglottis",
         "aliases": [
@@ -119,80 +63,10 @@
         ]
     },
     {
-        "id": "ILX:0786141",
-        "name": "Fifth thoracic ganglion",
-        "aliases": [
-            "FMA:6478"
-        ]
-    },
-    {
-        "id": "ILX:0789862",
-        "name": "First lumbar ganglion",
-        "aliases": [
-            "FMA:6540"
-        ]
-    },
-    {
-        "id": "ILX:0789109",
-        "name": "First sacral ganglion",
-        "aliases": [
-            "FMA:6552"
-        ]
-    },
-    {
-        "id": "ILX:0790472",
-        "name": "Fourth lumbar ganglion",
-        "aliases": [
-            "FMA:6543"
-        ]
-    },
-    {
-        "id": "ILX:0786272",
-        "name": "Fourth thoracic ganglion",
-        "aliases": [
-            "FMA:6477"
-        ]
-    },
-    {
         "id": "UBERON:0001649",
         "name": "glossopharyngeal nerve",
         "aliases": [
             "ILX:0723837"
-        ]
-    },
-    {
-        "id": "ILX:0785825",
-        "name": "Gray communicating ramus of first lumbar nerve",
-        "aliases": [
-            "FMA:65910"
-        ]
-    },
-    {
-        "id": "ILX:0793228",
-        "name": "Gray communicating ramus of first sacral nerve",
-        "aliases": [
-            "FMA:65986"
-        ]
-    },
-    {
-        "id": "ILX:0788536",
-        "name": "Gray communicating ramus of fourth lumbar nerve",
-        "aliases": [
-            "FMA:65913"
-        ]
-    },
-    {
-        "id": "ILX:0785733",
-        "name": "Gray communicating ramus of second lumbar nerve",
-        "aliases": [
-            "FMA:65911"
-        ]
-    },
-    {
-        "id": "ILX:0785932",
-        "name": "Gray communicating ramus of third lumbar nerve",
-        "aliases": [
-            "FMA:65912"
         ]
     },
     {
@@ -206,15 +80,7 @@
         "id": "UBERON:0002440",
         "name": "inferior cervical ganglion",
         "aliases": [
-            "FMA:6961",
             "ILX:0734766"
-        ]
-    },
-    {
-        "id": "UBERON:0002022",
-        "name": "insula",
-        "aliases": [
-            "FMA:67329"
         ]
     },
     {
@@ -235,24 +101,21 @@
         "id": "UBERON:0001896",
         "name": "medulla oblongata",
         "aliases": [
-            "ILX:0738301",
-            "FMA:61108"
+            "ILX:0738301"
         ]
     },
     {
         "id": "UBERON:0001891",
         "name": "midbrain",
         "aliases": [
-            "ILX:0106935",
-            "FMA:61993"
+            "ILX:0106935"
         ]
     },
     {
         "id": "UBERON:0001990",
         "name": "middle cervical ganglion",
         "aliases": [
-            "ILX:0726454",
-            "FMA:6468"
+            "ILX:0726454"
         ]
     },
     {
@@ -266,15 +129,7 @@
         "id": "UBERON:0005020",
         "name": "mucosa of tongue",
         "aliases": [
-            "ILX:0731712",
-            "FMA:54807"
-        ]
-    },
-    {
-        "id": "UBERON:0001719",
-        "name": "nucleus ambiguus",
-        "aliases": [
-            "FMA:54588"
+            "ILX:0731712"
         ]
     },
     {
@@ -295,29 +150,7 @@
         "id": "UBERON:0000988",
         "name": "pons",
         "aliases": [
-            "ILX:0109019",
-            "FMA:67943"
-        ]
-    },
-    {
-        "id": "UBERON:0002078",
-        "name": "right cardiac atrium",
-        "aliases": [
-            "FMA:7096"
-        ]
-    },
-    {
-        "id": "ILX:0786933",
-        "name": "Second lumbar ganglion",
-        "aliases": [
-            "FMA:6541"
-        ]
-    },
-    {
-        "id": "ILX:0786228",
-        "name": "Second thoracic ganglion",
-        "aliases": [
-            "FMA:6475"
+            "ILX:0109019"
         ]
     },
     {
@@ -328,18 +161,10 @@
         ]
     },
     {
-        "id": "ILX:0789947",
-        "name": "Sixth thoracic ganglion",
-        "aliases": [
-            "FMA:6479"
-        ]
-    },
-    {
         "id": "UBERON:0001989",
         "name": "superior cervical ganglion",
         "aliases": [
-            "ILX:0725956",
-            "FMA:6467"
+            "ILX:0725956"
         ]
     },
     {
@@ -347,20 +172,6 @@
         "name": "superior laryngeal nerve",
         "aliases": [
             "ILX:0731053"
-        ]
-    },
-    {
-        "id": "ILX:0788315",
-        "name": "Third lumbar ganglion",
-        "aliases": [
-            "FMA:6542"
-        ]
-    },
-    {
-        "id": "ILX:0786722",
-        "name": "Third thoracic ganglion",
-        "aliases": [
-            "FMA:6476"
         ]
     },
     {
@@ -392,45 +203,10 @@
         ]
     },
     {
-        "id": "ILX:0787009",
-        "name": "Twelfth thoracic ganglion",
-        "aliases": [
-            "FMA:6485"
-        ]
-    },
-    {
         "id": "UBERON:0001759",
         "name": "vagus nerve",
         "aliases": [
             "ILX:0733375"
-        ]
-    },
-    {
-        "id": "ILX:0738326",
-        "name": "Wall of larynx",
-        "aliases": [
-            "FMA:64182"
-        ]
-    },
-    {
-        "id": "ILX:0793220",
-        "name": "White communicating ramus of first lumbar anterior ramus",
-        "aliases": [
-            "FMA:12697"
-        ]
-    },
-    {
-        "id": "ILX:0793221",
-        "name": "White communicating ramus of second lumbar anterior ramus",
-        "aliases": [
-            "FMA:12698"
-        ]
-    },
-    {
-        "id": "ILX:0793361",
-        "name": "White communicating ramus of third lumbar anterior ramus",
-        "aliases": [
-            "FMA:12699"
         ]
     },
     {

--- a/connectivity_terms.json
+++ b/connectivity_terms.json
@@ -1,33 +1,5 @@
 [
     {
-        "id": "ILX:0791148",
-        "name": "Anterior root of fifth lumbar nerve",
-        "aliases": [
-            "EMAPA:25277"
-        ]
-    },
-    {
-        "id": "ILX:0785421",
-        "name": "Anterior root of first lumbar nerve",
-        "aliases": [
-            "EMAPA:25269"
-        ]
-    },
-    {
-        "id": "ILX:0792853",
-        "name": "Anterior root of first sacral nerve",
-        "aliases": [
-            "EMAPA:25281"
-        ]
-    },
-    {
-        "id": "ILX:0788675",
-        "name": "Anterior root of second lumbar nerve",
-        "aliases": [
-            "EMAPA:25271"
-        ]
-    },
-    {
         "id": "UBERON:0001508",
         "name": "arch of aorta",
         "aliases": [
@@ -154,13 +126,6 @@
         ]
     },
     {
-        "id": "ILX:0793360",
-        "name": "Sixth lumbar dorsal root ganglion",
-        "aliases": [
-            "EMAPA:25169"
-        ]
-    },
-    {
         "id": "UBERON:0001989",
         "name": "superior cervical ganglion",
         "aliases": [
@@ -172,20 +137,6 @@
         "name": "superior laryngeal nerve",
         "aliases": [
             "ILX:0731053"
-        ]
-    },
-    {
-        "id": "ILX:0793359",
-        "name": "Thirteenth thoracic dorsal root ganglion",
-        "aliases": [
-            "EMAPA:25186"
-        ]
-    },
-    {
-        "id": "ILX:0793357",
-        "name": "Thirteenth thoracic spinal cord segment",
-        "aliases": [
-            "EMAPA:19554"
         ]
     },
     {

--- a/properties.json
+++ b/properties.json
@@ -2210,9 +2210,6 @@
         "bolser_7-1": {
             "class": "bolser_7"
         },
-        "bolser_8-1": {
-            "class": "bolser_8"
-        },
         "brain_10-2": {
             "class": "brain_10"
         },
@@ -4270,7 +4267,7 @@
             "class": "auto-hide"
         },
         "plexus_5-1": {
-            "models": "FMA:6225",
+            "models": "ILX:0793704",
             "name": "esophageal nerve plexus",
             "type": "ganglion",
             "class": "auto-hide"
@@ -4483,7 +4480,7 @@
         },
         "vagus_1": {
             "type": "nerve",
-            "models": "FMA:6232"
+            "models": "ILX:0793829"
         },
         "vagus_2": {
             "type": "nerve",
@@ -4639,7 +4636,7 @@
         },
         "vagus_7": {
             "type": "nerve",
-            "models": "FMA:77213"
+            "models": "ILX:0774697"
         },
         "vagus_8": {
             "type": "nerve",
@@ -4691,7 +4688,7 @@
         },
         "vagus_11": {
             "type": "nerve",
-            "models": "FMA:6231"
+            "models": "ILX:0793828"
         },
         "pharyngeal_vagus_1": {
             "type": "nerve",
@@ -4715,7 +4712,7 @@
         },
         "vagus_14": {
             "type": "nerve",
-            "models": "FMA:6233"
+            "models": "ILX:0793830"
         },
         "phrenic_n": {
             "type": "nerve",
@@ -4979,7 +4976,7 @@
                 },
                 {
                     "id": "gloss_vagus_comm_1",
-                    "models": "FMA:6233",
+                    "models": "ILX:0793830",
                     "connects": [
                         "ganglion_1-1",
                         "gloss_vagus_comm_point"
@@ -4987,7 +4984,7 @@
                 },
                 {
                     "id": "meningeal_vagus_1",
-                    "models": "FMA:6231",
+                    "models": "ILX:0793828",
                     "connects": [
                         "ganglion_1-1",
                         "meningeal_vagus_1_branching_point"
@@ -4995,7 +4992,7 @@
                 },
                 {
                     "id": "auricular_vagus_1",
-                    "models": "FMA:6232",
+                    "models": "ILX:0793829",
                     "connects": [
                         "ganglion_2-1",
                         "AVN_point_1"
@@ -5526,7 +5523,7 @@
                 },
                 {
                     "id": "pancreas_vagus_1",
-                    "models": "FMA:77213",
+                    "models": "ILX:0774697",
                     "connects": [
                         "vagus_point_10",
                         "digestive_9-1"


### PR DESCRIPTION
In this PR, I've:
- Remove unused feature `bolser_8`
- Replace FMA terms with ILX terms
- Remove unused FMA terms from `connectivity_terms.json` file